### PR TITLE
Fix headers being immutable error

### DIFF
--- a/src/plugins/cache/expirationPlugin.ts
+++ b/src/plugins/cache/expirationPlugin.ts
@@ -24,6 +24,13 @@ class ExpirationPlugin implements StrategyPlugin {
     const now = Date.now();
 
     const expirationDate = options.cachedResponse.headers.get("X-Expires");
+    const newResponse = options.cachedResponse.clone()
+    const headers = new Headers(newResponse.headers)
+    const modifedResponse = new Response(newResponse.body, {
+      status: newResponse.status,
+      statusText: newResponse.statusText,
+      headers
+    })
 
     if (expirationDate) {
       const elapsedTime = new Date(expirationDate).getTime() - now;
@@ -35,19 +42,19 @@ class ExpirationPlugin implements StrategyPlugin {
         return options.cachedResponse;
       }
 
-      options.cachedResponse.headers.set(
+      modifedResponse.headers.set(
         "X-Access-Time",
         new Date(now).toUTCString()
       );
 
-      return options.cachedResponse;
+      return modifedResponse
     } else {
-      options.cachedResponse.headers.set(
+      modifedResponse.headers.set(
         "X-Access-Time",
         new Date(now).toUTCString()
       );
 
-      return options.cachedResponse;
+      return modifedResponse;
     }
   }
 
@@ -60,12 +67,20 @@ class ExpirationPlugin implements StrategyPlugin {
     console.log("cacheWillUpdate", options.request.url);
 
     let newResponse = options.response.clone();
-    newResponse.headers.set(
+    const headers = new Headers(newResponse.headers)
+
+    const modifedResponse = new Response(newResponse.body, {
+      status: newResponse.status,
+      statusText: newResponse.statusText,
+      headers
+    })
+
+    modifedResponse.headers.set(
       "X-Expires",
       new Date(now + this.maxAgeSeconds * 1_000).toUTCString()
     );
 
-    return newResponse;
+    return modifedResponse;
   }
 
   async cacheDidUpdate(options: {

--- a/src/strategy/cacheFirst.ts
+++ b/src/strategy/cacheFirst.ts
@@ -31,11 +31,11 @@ export class CacheFirst extends CacheStrategy {
     });
 
     if (cachedResponse) {
-      let res: Promise<null | Response> = new Promise(() => cachedResponse);
+      let res: Response | null = cachedResponse
 
       for (const plugin of this.plugins) {
         if (plugin.cachedResponseWillBeUsed) {
-          res = plugin.cachedResponseWillBeUsed({
+          res = await plugin.cachedResponseWillBeUsed({
             cacheName: this.cacheName,
             request,
             cachedResponse,
@@ -106,7 +106,7 @@ export class CacheFirst extends CacheStrategy {
     }
 
     if (newResponse) {
-      await cache.put(request, response.clone());
+      await cache.put(request, newResponse.clone());
 
       for (const plugin of this.plugins) {
         if (plugin.cacheDidUpdate) {


### PR DESCRIPTION
Fixed the headers being immutable error along with with few issues in the implementation of `CacheFirst` strategy.

I have only got it working with the assets cache because this plugin is only for that `CacheFirst` strategy. I had tried to get it working with document by using the `CacheFirst` strategy for document but couldn't get it working. Currently no idea why this is happening but i doubt the message handler implementation.