### PR TITLE
Add github actions for build test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build & Typecheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setting Up Node Environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "A Remix PWA package to help you build anything Service Workers in Remix. Complete with extensibility and a little zing 🚀",
   "private": false,
   "license": "MIT",
-  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/remix-pwa/sw"


### PR DESCRIPTION
Adding github actions for testing build scripts on PRs.

Supposed to solve #9 because the build script is working as expected when i tried but there was a small issue, I had forgot to remove `type=module` from package.json which caused the @remix-pwa/sw package being esm only package error to persist.