### PR TITLE
fix(networkFirst): return new `Response` object instead of mutating it

### DIFF
--- a/src/strategy/networkFirst.ts
+++ b/src/strategy/networkFirst.ts
@@ -28,11 +28,18 @@ export class NetworkFirst extends CacheStrategy {
     } catch (error) {
       let err = toError(error);
 
+     
       const cachedResponse = await cache.match(request, this.matchOptions);
+      if(cachedResponse){
+      const body = cachedResponse.clone().body;
+      const headers = new Headers(cachedResponse.clone().headers);
 
-      if (cachedResponse) {
-        cachedResponse.headers.set('X-Remix-Worker', 'yes');
-        return cachedResponse;
+      const newResponse = new Response(body, {
+        headers: {...headers, 'X-Remix-Worker': 'yes'},
+        status: cachedResponse.status,
+        statusText: cachedResponse.statusText,
+      });
+      return newResponse;
       }
 
       // throw error;


### PR DESCRIPTION
## WHY
When running the sw in Safari offline it produces the following error: 
`FetchEvent.responseWith received an error: Headers object’s guard is TypeError ‘immutable’ (WebKitServiceWorker:0)`

See [the open issue about this](https://github.com/remix-pwa/sw/issues/18) for more info.

## WHAT 
We have updated the logic in the `networkFirst` class to return a new `Response` object instead of mutating the existing one. 