### PR TITLE
feat(loader): allow registration all opts

### DIFF
--- a/src/react/loader.ts
+++ b/src/react/loader.ts
@@ -9,19 +9,20 @@ declare global {
   }
 }
 
-export type LoadServiceWorkerOptions = {
-  scope?: string;
+export type LoadServiceWorkerOptions = RegistrationOptions & {
   serviceWorkerUrl?: string;
 };
+
 
 /**
  * Load service worker in `entry.client` when the client gets hydrated.
  *
  * All parameters are optional.
  *
- * @param {string} LoadServiceWorkerOptions.scope - Scope of the service worker.
- * @param {string} LoadServiceWorkerOptions.serviceWorkerUrl - URL of the service worker.
- *
+ * @param  options - Options for loading the service worker.
+ * @param  options.serviceWorkerUrl='/entry.worker.js' - URL of the service worker.
+ * @param  ...options.registrationOptions - Options for the service worker registration.
+ * @returns 
  * ```ts
  * loadServiceWorker({
  *  scope: "/",
@@ -30,7 +31,7 @@ export type LoadServiceWorkerOptions = {
  * ```
  */
 export function loadServiceWorker(
-  options: LoadServiceWorkerOptions = {
+  {serviceWorkerUrl, ...options}: LoadServiceWorkerOptions = {
     scope: '/',
     serviceWorkerUrl: '/entry.worker.js'
   }
@@ -40,9 +41,7 @@ export function loadServiceWorker(
       try {
         await navigator.serviceWorker
           //@ts-ignore
-          .register(options.serviceWorkerUrl, {
-            scope: options.scope
-          })
+          .register(serviceWorkerUrl, options)
           .then(() => navigator.serviceWorker.ready)
           .then(() => {
             logger.debug('Syncing manifest...');


### PR DESCRIPTION
This add all the registrationOption to the loader function

```ts
loadServiceWorker({
 serviceWorkerUrl: "/entry.worker.js",
 scope: "/",
 type:'module'
})
```

this will not have any breaking change on the current api, but maybe we should match directly the registration signature instead

```ts
loadServiceWorker("/entry.worker.js", {
 scope: "/",
 type:'module'
})
```

WDYT @ShafSpecs ?