### PR TITLE
feat(swLoader): add an optional registration cb

### DIFF
--- a/src/react/loader.ts
+++ b/src/react/loader.ts
@@ -11,8 +11,10 @@ declare global {
 
 export type LoadServiceWorkerOptions = RegistrationOptions & {
   serviceWorkerUrl?: string;
+  serviceWorkerregistraionCallback?: (
+    registration: ServiceWorkerRegistration
+  ) => Promise<void> | void;
 };
-
 
 /**
  * Load service worker in `entry.client` when the client gets hydrated.
@@ -21,8 +23,9 @@ export type LoadServiceWorkerOptions = RegistrationOptions & {
  *
  * @param  options - Options for loading the service worker.
  * @param  options.serviceWorkerUrl='/entry.worker.js' - URL of the service worker.
+ * @param  options.serviceWorkerregistraionCallback - Callback function when the service worker gets registered.
  * @param  ...options.registrationOptions - Options for the service worker registration.
- * @returns 
+ * @returns
  * ```ts
  * loadServiceWorker({
  *  scope: "/",
@@ -31,38 +34,47 @@ export type LoadServiceWorkerOptions = RegistrationOptions & {
  * ```
  */
 export function loadServiceWorker(
-  {serviceWorkerUrl, ...options}: LoadServiceWorkerOptions = {
+  {
+    serviceWorkerUrl,
+    serviceWorkerregistraionCallback,
+    ...options
+  }: LoadServiceWorkerOptions = {
     scope: '/',
-    serviceWorkerUrl: '/entry.worker.js'
+    serviceWorkerUrl: '/entry.worker.js',
+    serviceWorkerregistraionCallback: () => {}
   }
 ) {
   if ('serviceWorker' in navigator) {
     async function register() {
+      const syncRemixManifest = (
+        serviceWorker: ServiceWorkerContainer = navigator.serviceWorker
+      ) => {
+        serviceWorker.controller?.postMessage({
+          type: 'SYNC_REMIX_MANIFEST',
+          manifest: window.__remixManifest
+        });
+      };
+
       try {
-        await navigator.serviceWorker
-          //@ts-ignore
-          .register(serviceWorkerUrl, options)
-          .then(() => navigator.serviceWorker.ready)
-          .then(() => {
+        const registration = await navigator.serviceWorker.register(
+          serviceWorkerUrl!,
+          options
+        );
+
+        await serviceWorkerregistraionCallback?.(registration);
+
+        await navigator.serviceWorker.ready;
+
+        logger.debug('Syncing manifest...');
+
+        if (navigator.serviceWorker.controller) {
+          syncRemixManifest();
+        } else {
+          navigator.serviceWorker.addEventListener('controllerchange', () => {
             logger.debug('Syncing manifest...');
-            if (navigator.serviceWorker.controller) {
-              navigator.serviceWorker.controller.postMessage({
-                type: 'SYNC_REMIX_MANIFEST',
-                manifest: window.__remixManifest
-              });
-            } else {
-              navigator.serviceWorker.addEventListener(
-                'controllerchange',
-                () => {
-                  logger.debug('Syncing manifest...');
-                  navigator.serviceWorker.controller?.postMessage({
-                    type: 'SYNC_REMIX_MANIFEST',
-                    manifest: window.__remixManifest
-                  });
-                }
-              );
-            }
+            syncRemixManifest();
           });
+        }
       } catch (error) {
         // console.error('Service worker registration failed', error);
       }


### PR DESCRIPTION
### changes:

tl;dr

- moved the logit to Async/await instead of chaining thens
- add a registration cb function to allow working with the registration object



### need:

After registering a service worker, can be tricky sometimes to handle updates and sometime a foce update logic is needed using the registration instance.

### solution

on this solution we add an optional serviceWorkerregistraionCallback function to the `loadServiceWorker` allowing the user to customize the registration lifecycles.

ref: https://web.dev/service-worker-lifecycle/#handling-updates
https://web.dev/service-worker-lifecycle/#manual-updates 

